### PR TITLE
Feat/add repeat function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -108,6 +108,7 @@ client.on('interactionCreate', async interaction => {
 		if (subscription) {
       if (interaction.options.getSubcommand() === 'song') {
         subscription.repeatSong();
+        await interaction.reply('Repeating current song!');
       }
 		} else {
 			await interaction.reply('Not playing in this server!');

--- a/index.ts
+++ b/index.ts
@@ -9,10 +9,6 @@ import { Track } from './src/music/track';
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_VOICE_STATES]})
 const subscriptions = new Map<Snowflake, MusicSubscription>();
 
-client.once('ready', () => {
-  console.log('ready!');
-});
-
 client.on('interactionCreate', async interaction => {
   if (!interaction.isCommand() || !interaction.guildId) return;
 
@@ -108,10 +104,14 @@ client.on('interactionCreate', async interaction => {
 		} else {
 			await interaction.reply('Not playing in this server!');
 		}
-	} else if (interaction.commandName === 'loop') {
-    if (subscription) {
-      subscription.loop();
-    }
+	} else if (interaction.commandName === 'repeat') {
+		if (subscription) {
+      if (interaction.options.getSubcommand() === 'song') {
+        subscription.repeatSong();
+      }
+		} else {
+			await interaction.reply('Not playing in this server!');
+		}    
   }
   });
   

--- a/index.ts
+++ b/index.ts
@@ -108,7 +108,11 @@ client.on('interactionCreate', async interaction => {
 		} else {
 			await interaction.reply('Not playing in this server!');
 		}
-	}
+	} else if (interaction.commandName === 'loop') {
+    if (subscription) {
+      subscription.loop();
+    }
+  }
   });
   
   

--- a/index.ts
+++ b/index.ts
@@ -107,7 +107,7 @@ client.on('interactionCreate', async interaction => {
 	} else if (interaction.commandName === 'repeat') {
 		if (subscription) {
       if (interaction.options.getSubcommand() === 'song') {
-        subscription.repeatSong();
+        subscription.repeatTrack();
         await interaction.reply('Repeating current song!');
       }
 		} else {

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -1,0 +1,3 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+
+export const data = new SlashCommandBuilder().setName('loop').setDescription('Loops the current song');

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -1,3 +1,0 @@
-import { SlashCommandBuilder } from '@discordjs/builders';
-
-export const data = new SlashCommandBuilder().setName('loop').setDescription('Loops the current song');

--- a/src/commands/repeat.ts
+++ b/src/commands/repeat.ts
@@ -1,0 +1,10 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+
+export const data = new SlashCommandBuilder()
+  .setName('repeat')
+  .setDescription('Repeats the song / playlist')
+  .addSubcommand(subcommand =>
+    subcommand
+      .setName('song')
+      .setDescription('Repeats the currently playing song')
+  )

--- a/src/music/subscription.ts
+++ b/src/music/subscription.ts
@@ -23,6 +23,7 @@ export class MusicSubscription {
   public queue: Track[];
   public queueLock = false;
   public readyLock = false;
+  public isLooping = false;
   
   public constructor(voiceConnection: VoiceConnection) {
     this.voiceConnection = voiceConnection;
@@ -119,6 +120,13 @@ export class MusicSubscription {
       this.queue = [];
       this.audioPlayer.stop(true);
     }
+
+    /**
+    * Toggles looping of the current song
+    */
+    public loop() {
+      this.isLooping = !this.isLooping;
+    }
     
     /**
     * Attempts to play a Track from the queue
@@ -131,8 +139,16 @@ export class MusicSubscription {
       // Lock the queue to guarantee safe access
       this.queueLock = true;
       
-      // Take the first item from the queue. This is guaranteed to exist due to the non-empty check above.
-      const nextTrack = this.queue.shift()!;
+      let nextTrack: Track;
+
+      if (this.isLooping) {
+        // If looping, take the current song in the queue.
+        nextTrack = this.queue[0];
+      } else {
+        // Take the first item from the queue. This is guaranteed to exist due to the non-empty check above.
+        nextTrack = this.queue.shift()!;
+      }
+
       try {
         // Attempt to convert the Track into an AudioResource (i.e. start streaming the video)
         const resource = await nextTrack.createAudioResource();

--- a/src/music/subscription.ts
+++ b/src/music/subscription.ts
@@ -140,15 +140,8 @@ export class MusicSubscription {
       // Lock the queue to guarantee safe access
       this.queueLock = true;
       
-      let nextTrack: Track;
-
-      if (this.isRepeatingSong) {
-        // If looping, take the current song in the queue.
-        nextTrack = this.queue[0];
-      } else {
-        // Take the first item from the queue. This is guaranteed to exist due to the non-empty check above.
-        nextTrack = this.queue.shift()!;
-      }
+      // Take the first item from the queue. This is guaranteed to exist due to the non-empty check above.
+      const nextTrack = this.queue.shift()!;
 
       try {
         // Attempt to convert the Track into an AudioResource (i.e. start streaming the video)

--- a/src/music/subscription.ts
+++ b/src/music/subscription.ts
@@ -23,7 +23,7 @@ export class MusicSubscription {
   public queue: Track[];
   public queueLock = false;
   public readyLock = false;
-  public isLooping = false;
+  public isRepeatingSong = false;
   
   public constructor(voiceConnection: VoiceConnection) {
     this.voiceConnection = voiceConnection;
@@ -117,15 +117,16 @@ export class MusicSubscription {
     */
     public stop() {
       this.queueLock = true;
+      this.isRepeatingSong = false;
       this.queue = [];
       this.audioPlayer.stop(true);
     }
 
     /**
-    * Toggles looping of the current song
+    * Toggles repeating of the song
     */
-    public loop() {
-      this.isLooping = !this.isLooping;
+    public repeatSong() {
+      this.isRepeatingSong = !this.isRepeatingSong;
     }
     
     /**
@@ -141,7 +142,7 @@ export class MusicSubscription {
       
       let nextTrack: Track;
 
-      if (this.isLooping) {
+      if (this.isRepeatingSong) {
         // If looping, take the current song in the queue.
         nextTrack = this.queue[0];
       } else {

--- a/src/music/track.ts
+++ b/src/music/track.ts
@@ -28,16 +28,43 @@ const noop = () => {};
 export class Track implements TrackData {
   public readonly url: string;
   public readonly title: string;
-  public readonly onStart: () => void;
-  public readonly onFinish: () => void;
   public readonly onError: (error: Error) => void;
+  public repeating: boolean;
+
+  private readonly wrapperOnStart: () => void;
+  private readonly wrapperOnFinish: () => void;
   
   private constructor({ url, title, onStart, onFinish, onError }: TrackData) {
     this.url = url;
     this.title = title;
-    this.onStart = onStart;
-    this.onFinish = onFinish;
+    this.repeating = false;
     this.onError = onError;
+    this.wrapperOnStart = onStart;
+    this.wrapperOnFinish = onFinish;
+  }
+
+  public toggleRepeating(): void {
+    this.repeating = !this.repeating;
+  }
+
+  /**
+   * If a track is being repeated, don't run onStart to prevent additional calls
+   * as it is *technically* not started
+   */
+  public onStart(): void {
+    if (!this.repeating) {
+      this.wrapperOnStart();
+    }
+  }
+
+  /**
+   * If a track is being repeated, don't run onFinish to prevent additional calls
+   * as it is *technically* not finished
+   */
+  public onFinish(): void {
+    if (!this.repeating) {
+      this.wrapperOnFinish();
+    }
   }
   
   /**


### PR DESCRIPTION
Adds a new slash command: `/repeat song`
- This repeats the current song. Typing it multiple times will toggle the boolean value.
- Wraps Track lifecycle hook methods to prevent unnecessary `interaction.followUp`s when the track is going to be replayed.